### PR TITLE
Potential fix for code scanning alert no. 12: Explicit returns mixed with implicit (fall through) returns

### DIFF
--- a/src/urwid_ui.py
+++ b/src/urwid_ui.py
@@ -404,6 +404,9 @@ class MainFrame(urwid.Frame):
         else:
             return self.search_box.keypress((maxcol,), key)
 
+        # If not handled above, explicitly return None
+        return None
+
     def filter(self, query):
         """Do the synchronised list box filter and search box autocomplete.
 


### PR DESCRIPTION
Potential fix for [https://github.com/caelyx/tv3/security/code-scanning/12](https://github.com/caelyx/tv3/security/code-scanning/12)

To fix this issue, add an explicit `return None` statement at the end of the `keypress` method. This will ensure it always returns a known value (`None`) if no other return is encountered, making the function’s behavior clearer. Only `src/urwid_ui.py` needs to be changed, specifically the `keypress` method in lines after the existing code branches.

No other imports, methods, or definitions are required.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
